### PR TITLE
[Win] Sửa lỗi crash ở hàm checkUpdate nếu không chạy bằng quyền Admin

### DIFF
--- a/Sources/OpenKey/win32/OpenKey/OpenKey/OpenKeyHelper.cpp
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/OpenKeyHelper.cpp
@@ -307,7 +307,7 @@ wstring OpenKeyHelper::getVersionString() {
 
 wstring OpenKeyHelper::getContentOfUrl(LPCTSTR url){
 	WCHAR path[MAX_PATH];
-	GetCurrentDirectory(MAX_PATH, path);
+	GetTempPath2(MAX_PATH, path);
 	wsprintf(path, TEXT("%s\\_OpenKey.tempf"), path);
 	HRESULT res = URLDownloadToFile(NULL, url, path, 0, NULL);
 	


### PR DESCRIPTION
Khi khởi động app bằng task scheduler thì hàm [GetCurrentDirectory](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcurrentdirectory) sẽ trả về `C:\Windows\System32`, nếu app không được chạy bằng quyền Admin thì sẽ không thể tạo được file `_OpenKey.tempf` và mình cũng không nên tạo file tạm ở thư mục này, thay vào đó hàm [GetTempPath2](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w) sẽ đảm bảo trả về 1 đường dẫn hợp lệ với quyền của user chạy app.

Mình cũng sửa lại thuật toán parse version cho an toàn hơn, phòng trường hợp không tải được `version.json` sẽ không gây chết app.