### PR TITLE
feat: Enable multi-user support by allowing multiple instances of OpenKey for different mac users

### DIFF
--- a/Sources/OpenKey/macOS/ModernKey/AppDelegate.m
+++ b/Sources/OpenKey/macOS/ModernKey/AppDelegate.m
@@ -10,6 +10,8 @@
 #import <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
 #import <ServiceManagement/ServiceManagement.h>
+#include <libproc.h>
+#include <sys/proc_info.h>
 #import "AppDelegate.h"
 #import "ViewController.h"
 #import "OpenKeyManager.h"
@@ -119,8 +121,26 @@ extern bool convertToolDontAlertWhenCompleted;
                                               forKey: @"NSInitialToolTipDelay"];
     
     //check whether this app has been launched before that or not
-    NSArray* runningApp = [[NSWorkspace sharedWorkspace] runningApplications];
-    if ([runningApp containsObject:OPENKEY_BUNDLE]) { //if already running -> exit
+    //Only check instances owned by current user (for multi-user/Fast User Switching support)
+    uid_t currentUID = getuid();
+    NSArray<NSRunningApplication *>* runningApps = [[NSWorkspace sharedWorkspace] runningApplications];
+    pid_t myPID = [[NSProcessInfo processInfo] processIdentifier];
+    BOOL alreadyRunning = NO;
+
+    for (NSRunningApplication *app in runningApps) {
+        if ([app.bundleIdentifier isEqualToString:OPENKEY_BUNDLE] &&
+            app.processIdentifier != myPID) {
+            pid_t pid = app.processIdentifier;
+            struct proc_bsdinfo proc;
+            int size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &proc, sizeof(proc));
+            if (size == sizeof(proc) && proc.pbi_uid == currentUID) {
+                alreadyRunning = YES;
+                break;
+            }
+        }
+    }
+
+    if (alreadyRunning) {
         [NSApp terminate:nil];
         return;
     }

--- a/Sources/OpenKey/macOS/ModernKey/Info.plist
+++ b/Sources/OpenKey/macOS/ModernKey/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSMultipleInstancesProhibited</key>
-	<true/>
+	<false/>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>

--- a/Sources/OpenKey/macOS/OpenKeyHelper/AppDelegate.m
+++ b/Sources/OpenKey/macOS/OpenKeyHelper/AppDelegate.m
@@ -7,6 +7,10 @@
 //
 
 #import "AppDelegate.h"
+#include <libproc.h>
+#include <sys/proc_info.h>
+
+#define OPENKEY_BUNDLE @"com.tuyenmai.openkey"
 
 @interface AppDelegate ()
 
@@ -16,8 +20,24 @@
 @implementation AppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
-    NSArray* runningApp = [[NSWorkspace sharedWorkspace] runningApplications];
-    if (![runningApp containsObject:@"com.tuyenmai.openkey"]) {
+    //Check if OpenKey is running for current user (multi-user/Fast User Switching support)
+    uid_t currentUID = getuid();
+    NSArray<NSRunningApplication *>* runningApps = [[NSWorkspace sharedWorkspace] runningApplications];
+    BOOL isRunning = NO;
+
+    for (NSRunningApplication *app in runningApps) {
+        if ([app.bundleIdentifier isEqualToString:OPENKEY_BUNDLE]) {
+            pid_t pid = app.processIdentifier;
+            struct proc_bsdinfo proc;
+            int size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &proc, sizeof(proc));
+            if (size == sizeof(proc) && proc.pbi_uid == currentUID) {
+                isRunning = YES;
+                break;
+            }
+        }
+    }
+
+    if (!isRunning) {
         NSString* path = [[NSBundle mainBundle] bundlePath];
         for (int i = 0; i < 4; i++)
             path = [path stringByDeletingLastPathComponent];


### PR DESCRIPTION
## Warning
This fix was written by Claude Code. It works on my mac. Use it with cautious

## Summary
  - Enable OpenKey to run simultaneously for different macOS users (Fast User Switching support)
  - Change instance detection to only prevent duplicate instances per-user rather than system-wide
  - Allow multiple instances at system level by setting `LSMultipleInstancesProhibited` to `false`

  ## Changes
  Modifies the duplicate instance detection logic in both the main app (`ModernKey/AppDelegate.m`) and the helper app (`OpenKeyHelper/AppDelegate.m`) to check the UID of running processes using `proc_pidinfo`. Previously, the app would terminate if any instance of OpenKey was running on the system. Now it only terminates if another instance is running under the **same user**.

  **Files changed:**
  - `Sources/OpenKey/macOS/ModernKey/AppDelegate.m` - Updated instance detection to check process UID
  - `Sources/OpenKey/macOS/ModernKey/Info.plist` - Set `LSMultipleInstancesProhibited` to `false`
  - `Sources/OpenKey/macOS/OpenKeyHelper/AppDelegate.m` - Updated instance detection to check process UID

  🤖 Generated with [Claude Code](https://claude.com/claude-code)